### PR TITLE
Update zeroize to v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "0.9.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"


### PR DESCRIPTION
Fixes issue #8 regarding broken `zeroize` version dependency